### PR TITLE
feat: use log-method provided by Pumpkin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello-pumpkin"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
@@ -13,9 +13,10 @@ pumpkin-data = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "ma
 pumpkin-protocol = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin-protocol" }
 pumpkin-api-macros = { git = "https://github.com/Pumpkin-MC/Pumpkin.git", branch = "master", package = "pumpkin-api-macros" }
 
-async-trait = "0.1.83"
-tokio = { version = "1.42", features = ["full"] }
+tokio = { version = "1.49", features = ["full"] }
+rand = "0.10.0"
 
-env_logger = "0.11.6"
-log = "0.4.22"
-rand = "0.9.1"
+[profile.release]
+lto = true
+strip = "debuginfo"
+codegen-units = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,25 +1,23 @@
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use pumpkin::{
     command::{
-        args::ConsumedArgs,
-        tree::{builder::literal, CommandTree},
         CommandExecutor, CommandResult, CommandSender,
+        args::ConsumedArgs,
+        tree::{CommandTree, builder::literal},
     },
     plugin::{
-        player::player_join::PlayerJoinEvent, BoxFuture, Context, EventHandler, EventPriority,
+        BoxFuture, Context, EventHandler, EventPriority, player::player_join::PlayerJoinEvent,
     },
     server::Server,
 };
 use pumpkin_api_macros::{plugin_impl, plugin_method, with_runtime};
 use pumpkin_util::permission::{Permission, PermissionDefault};
-use pumpkin_util::text::{color::NamedColor, TextComponent};
-use rand::{rng, Rng};
+use pumpkin_util::text::{TextComponent, color::NamedColor};
+use rand::{RngExt, rng};
 
 struct MyJoinHandler;
 
-#[with_runtime(global)]
 impl EventHandler<PlayerJoinEvent> for MyJoinHandler {
     fn handle_blocking<'a>(
         &self,
@@ -39,7 +37,7 @@ const DESCRIPTION: &str = "Play Rock Paper Scissors with the server.";
 
 struct RockPaperScissorsExecutor(Choice);
 
-#[async_trait]
+#[with_runtime(global)]
 impl CommandExecutor for RockPaperScissorsExecutor {
     fn execute<'a>(
         &'a self,
@@ -89,7 +87,7 @@ impl CommandExecutor for RockPaperScissorsExecutor {
                 }
             }
 
-            Ok(())
+            Ok(1)
         })
     }
 }
@@ -98,7 +96,7 @@ impl CommandExecutor for RockPaperScissorsExecutor {
 async fn on_load(&mut self, server: Arc<Context>) -> Result<(), String> {
     server.init_log();
 
-    log::info!("Hello, Pumpkin!");
+    server.log("Hello, Pumpkin!");
 
     server
         .register_event(Arc::new(MyJoinHandler), EventPriority::Lowest, true)


### PR DESCRIPTION
Instead of using the log-crate directly, call a log-function from the plugin-context in Pumpkin; depends on https://github.com/Pumpkin-MC/Pumpkin/pull/1460 being merged first

Return an integer on execute to match what CommandExecute expects